### PR TITLE
Fix: Set function not registering in kissmetrics 

### DIFF
--- a/lib/snogmetrics.rb
+++ b/lib/snogmetrics.rb
@@ -103,7 +103,7 @@ private
 
     # Register which variant the user saw in an A/B test.
     def set(experiment, variant)
-      queue << ['set', experiment, variant]
+      queue << ['set', { experiment => variant }]
     end
     
     # Equivalent to `js(:reset => true)`, i.e. returns the JavaScript code

--- a/spec/snogmetrics_spec.rb
+++ b/spec/snogmetrics_spec.rb
@@ -106,7 +106,7 @@ describe Snogmetrics do
   describe '#set' do
     it 'will output code that pushes a set call with the provided experiment name and variant' do
       @context.km.set('My Awesome Experiment', 'variant_a')
-      @context.km.js.should include('_kmq.push(["set","My Awesome Experiment","variant_a"])')
+      @context.km.js.should include('_kmq.push(["set",{"My Awesome Experiment":"variant_a"}])')
     end
   end
   


### PR DESCRIPTION
Fixes issue https://github.com/iconara/snogmetrics/issues/5

Provides a hash of properties as per http://support.kissmetrics.com/apis/common-methods#set
