### PR TITLE
Fixing the README typo.

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -12,7 +12,7 @@ It's true, but why settle for either or?
 
 SNOGmetrics works similarly to flash messages. Events are recorded and saved to the session, and are then sent when the next page is rendered. This way you get all of the benefits of the JavaScript API, but you can record events in your controllers. All you have to do is install this gem, configure it, and add a snipplet of code to your layout.
 
-## How do I use it?
+## Rails > 2.3.5 How do I use it?
 
 1. `gem install snogmetrics`
 2. Edit `config/environment.rb` and add `config.gem 'snogmetrics'`
@@ -21,6 +21,22 @@ SNOGmetrics works similarly to flash messages. Events are recorded and saved to 
 5. Replace all your `KM.record(...)` and `KM.identify(...)` calls in JavaScript with calls to `km.record(...)` and `km.identify(...)`
 
 Have a look at the included example application to see it in action.
+
+
+## Rails 3 How do I use it?
+
+1. Add `snogmetrics` in your gemfile and run the bundle command to install it
+2. Add an initializer file like the following under your config/initializers folder
+***
+rails_env = ENV['RAILS_ENV'] || 'development'
+KISSMETRICS_CONFIG ||= YAML.load_file("#{Rails.root}/config/kissmetrics.yml")[rails_env]
+require 'snogmetrics'
+Snogmetrics.send(:define_method, :kissmetrics_api_key) { KISSMETRICS_CONFIG['api_key'] }
+ActionController::Base.send(:include, Snogmetrics)
+ActionView::Base.send(:include, Snogmetrics)
+
+3. Edit your layout(s) and add `<%= km.js.html_safe %>` where you keep your JavaScript includes.
+5. Replace all your `KM.record(...)` and `KM.identify(...)` calls in JavaScript with calls to `km.record(...)` and `km.identify(...)`
 
 ## Does it use the asynchronous API?
 


### PR DESCRIPTION
In the "How to use it section" there is a typo in the snipped suggested for inclusion in the layout. 
It should be <%= km.js! %> instead of <%== km.js! %>
